### PR TITLE
Multiple layers of nesting of types with args raise recursion errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/dswistowski/svarog",
-    version="0.1.2",
+    version="0.1.3",
     zip_safe=False,
 )

--- a/svarog/svarog.py
+++ b/svarog/svarog.py
@@ -55,8 +55,8 @@ class Svarog:
                 and sub_type is not Any
                 and hasattr(sub_type, "__args__")
             ):
-                for sub_type in annotation.__args__:
-                    update_subtype(sub_type)
+                for arg in sub_type.__args__:
+                    update_subtype(arg)
 
         for _, annotation in _clean_annotations(type_.__init__):
             update_subtype(annotation)

--- a/tests/test_svarog.py
+++ b/tests/test_svarog.py
@@ -227,3 +227,11 @@ def test_can_build_if_there_is_default(forge):
         x: int = 0
 
     assert forge(A, {"x": 42}) == A(42)
+
+
+def test_can_build_nested_types_with_args(forge):
+    @dataclass
+    class A:
+        x: Optional[Mapping[str, Any]] = None
+
+    assert forge(A, {"x": {"foo": "bar"}}) == A(x={"foo": "bar"})


### PR DESCRIPTION
Fixes the following:
```
_______________________________________________________________________________________________________________________________________ test_can_build_nested_types_with_args _______________________________________________________________________________________________________________________________________

forge = <bound method Svarog.forge of <svarog.svarog.Svarog object at 0x10f159518>>

    def test_can_build_nested_types_with_args(forge):
        @dataclass
        class A:
            x: Optional[Mapping[str, Any]] = None
    
>       assert forge(A, {"x": {"foo": "bar"}}) == A(x={"foo": "bar"})

tests/test_svarog.py:237: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.pyenv/versions/3.7.0/envs/svarog-370/lib/python3.7/site-packages/svarog-0.1.2-py3.7.egg/svarog/svarog.py:69: in forge
    self._update_forward_ref_owners_registry(type_)
../../.pyenv/versions/3.7.0/envs/svarog-370/lib/python3.7/site-packages/svarog-0.1.2-py3.7.egg/svarog/svarog.py:62: in _update_forward_ref_owners_registry
    update_subtype(annotation)
../../.pyenv/versions/3.7.0/envs/svarog-370/lib/python3.7/site-packages/svarog-0.1.2-py3.7.egg/svarog/svarog.py:59: in update_subtype
    update_subtype(sub_type)
../../.pyenv/versions/3.7.0/envs/svarog-370/lib/python3.7/site-packages/svarog-0.1.2-py3.7.egg/svarog/svarog.py:59: in update_subtype
    update_subtype(sub_type)
E   RecursionError: maximum recursion depth exceeded while calling a Python object
!!! Recursion detected (same locals & position)
```